### PR TITLE
fixed linuxFreeMemory typo, added check for MemAvailable

### DIFF
--- a/lib/mem.js
+++ b/lib/mem.js
@@ -12,7 +12,7 @@ var co = require('../util/co')
 var util = require('../util')
 var exec = require('./exec')
 
-var linuxFreeMemroy = function () {
+var linuxFreeMemory = function () {
   return new Promise(function (resolve) {
     // https://github.com/SunilWang/node-os-utils/pull/11
     // running this on an embedded linux device. This steps takes around 500ms. With this change we brought it down to a few milliseconds.
@@ -28,6 +28,11 @@ var linuxFreeMemroy = function () {
       })
 
       var totalMem = parseInt(memInfo.MemTotal, 10) * 1024
+
+      // check if MemAvailable exists
+      if (!memInfo.MemAvailable) {
+        memInfo.MemAvailable = memInfo['MemFree'] + memInfo['Buffers'] + memInfo['Cached'] + memInfo['SReclaimable'] - memInfo['Shmem'];
+      }
       var freeMem = memInfo.MemAvailable * 1024
 
       // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
@@ -116,7 +121,7 @@ bucket.mem = {
   info: co.wrap(function* () {
     var totalMem = null
     var freeMem = null
-    var memInfo = yield linuxFreeMemroy()
+    var memInfo = yield linuxFreeMemory()
 
     if (bucket.isNotSupported(memInfo)) {
       totalMem = os.totalmem() / 1024


### PR DESCRIPTION
I currently am using WSL, which doesn't have the `MemAvailable` metric in `/proc/meminfo`. Additionally, `MemAvailable` was added in the Linux 3.14 kernel, so this PR should help those with older kernels installed. This is what is contained in the `memInfo` object after calling `mem.info()`:
```
{
  totalMemMb: 16303.29,
  usedMemMb: NaN,
  freeMemMb: NaN,
  freeMemPercentage: NaN
}
```
I have added a check to see if that property exists, and if not it will be calculated. After adding the fix, here is the new contents of `memInfo` on my machine, which seems to be fairly accurate:
```
{
  totalMemMb: 16303.29,
  usedMemMb: 9113.89,
  freeMemMb: 7189.4,
  freeMemPercentage: 44.1
}
```

I also fixed a typo, renaming `linuxFreeMemroy` to `linuxFreeMemory`.