### PR TITLE
fix calculations

### DIFF
--- a/lib/drive.js
+++ b/lib/drive.js
@@ -66,16 +66,16 @@ bucket.drive = {
         diskInfo = main
       }
 
-      var total = Math.ceil(((diskInfo['1K-blocks'] || diskInfo['1024-blocks']) * 1024) / Math.pow(1024, 2))
       var used = Math.ceil(diskInfo.Used * 1024 / Math.pow(1024, 2))
       var free = Math.ceil((diskInfo.Available || diskInfo.Avail) * 1024 / Math.pow(1024, 2))
+      var total = used + free;
 
       var totalGb = (total / 1024).toFixed(1)
       var usedGb = (used / 1024).toFixed(1)
       var freeGb = (free / 1024).toFixed(1)
 
-      var usedPercentage = (100 * usedGb / totalGb).toFixed(1)
-      var freePercentage = (100 * freeGb / totalGb).toFixed(1)
+      var usedPercentage = (100 * used / total).toFixed(1)
+      var freePercentage = (100 * free / total).toFixed(1)
 
       return Promise.resolve({
         totalGb: totalGb,


### PR DESCRIPTION
- calculate "total = free + used" rather than using number of 1k blocks (there's non-allocatable space on the disk)
- calculate percentages by using non-rounded metrics