### PR TITLE
fix: netstat inOut interval

### DIFF
--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -162,8 +162,8 @@ bucket.netstat = {
       for (var i = 0; i < oldStats.length; i++) {
         if (oldStats[i].interface !== 'lo' && oldStats[i].interface !== 'lo0' && oldStats[i].inputBytes > 0 && oldStats[i].outputBytes > 0) {
           metrics[oldStats[i].interface] = {}
-          metrics[oldStats[i].interface]['inputMb'] = parseFloat(((newStats[i].inputBytes - oldStats[i].inputBytes) / interval * 1000 / 1000000).toFixed(2))
-          metrics[oldStats[i].interface]['outputMb'] = parseFloat(((newStats[i].outputBytes - oldStats[i].outputBytes) / interval * 1000 / 1000000).toFixed(2))
+          metrics[oldStats[i].interface]['inputMb'] = parseFloat(((newStats[i].inputBytes - oldStats[i].inputBytes) / 1000000).toFixed(2))
+          metrics[oldStats[i].interface]['outputMb'] = parseFloat(((newStats[i].outputBytes - oldStats[i].outputBytes) / 1000000).toFixed(2))
 
           metrics.total['inputMb'] += parseFloat(metrics[oldStats[i].interface]['inputMb'])
           metrics.total['outputMb'] += parseFloat(metrics[oldStats[i].interface]['outputMb'])


### PR DESCRIPTION
- methods: netstat.inOut(interval):Promise(Object)
 [interval]: number - interval millisecond. defaulta: 1000

> I think inputMb and outputMb should not be affected by interval. Please correct any mistakes

```js
// Compute input output
metrics[oldStats[i].interface]['inputMb'] = parseFloat(((newStats[i].inputBytes - oldStats[i].inputBytes) / interval * 1000 / 1000000).toFixed(2))
metrics[oldStats[i].interface]['outputMb'] = parseFloat(((newStats[i].outputBytes - oldStats[i].outputBytes) / interval * 1000 / 1000000).toFixed(2))

// When I get it every 10 seconds, it's no longer accurate
netstat.inOut(10*1000) // 10s
```

